### PR TITLE
Add ability to run within a docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,3 @@ COPY . .
 
 RUN echo "--- Installing dependencies" && yarn
 CMD echo "--- Running lighthouse" && node auth.js
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get install -y chromium
 
 ENV HOME /app
+ENV HEADLESS true
 WORKDIR $HOME
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:13.12.0-buster-slim 
+
+RUN apt-get update && \
+    apt-get install -y chromium
+
+ENV HOME /app
+WORKDIR $HOME
+
+COPY . .
+
+RUN echo "--- Installing dependencies" && yarn
+CMD echo "--- Running lighthouse" && node auth.js
+
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ See: https://github.com/GoogleChrome/lighthouse#cli-options for more options
 Authenticated pages
 
 ```
+export EMAIL="<email>"
+export PASSWORD="<password>"
+export LOGIN_URL="<login_url>"
+export TARGET_URL="<target_url>"
 node auth.js
 ```
 
@@ -56,8 +60,14 @@ To run lighthouse via docker, execute the following:
 # Build docker image
 docker build -t lighthouse-test:latest -f Dockerfile .
 
+# Set required environment variables
+export EMAIL="<email>"
+export PASSWORD="<password>"
+export LOGIN_URL="<login_url>"
+export TARGET_URL="<target_url>"
+
 # Run image to execute lighthouse
-docker run --name lighthouse-container lighthouse-test:latest
+docker run --name lighthouse-container -e EMAIL -e PASSWORD -e LOGIN_URL -e TARGET_URL lighthouse-test:latest
 
 # Get lighthouse report
 docker cp  lighthouse-container:/app/report.html .
@@ -68,6 +78,5 @@ docker rm lighthouse-container
 
 ## Enhancements to make
 
-* Setting env vars for: EMAIL, PASSWORD, LOGINURL, TARGETURL
 * Use of budgets (TODO)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ See:
 * https://github.com/GoogleChrome/lighthouse/blob/master/docs/authenticated-pages.md
 * https://github.com/GoogleChrome/lighthouse/blob/master/docs/readme.md#using-programmatically
 
+## Running via Docker
+
+To run lighthouse via docker, execute the following:
+```
+# Build docker image
+docker build -t lighthouse-test:latest -f Dockerfile .
+
+# Run image to execute lighthouse
+docker run --name lighthouse-container lighthouse-test:latest
+
+# Get lighthouse report
+docker cp  lighthouse-container:/app/report.html .
+
+# Cleanup and remove container
+docker rm lighthouse-container
+```
+
 ## Enhancements to make
 
 * Setting env vars for: EMAIL, PASSWORD, LOGINURL, TARGETURL

--- a/auth.js
+++ b/auth.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const puppeteer = require('puppeteer');
 const lighthouse = require('lighthouse');
 
+const HEADLESS = true
 const PORT = 8041; //debugging port
 const EMAIL = ''
 const PASSWORD = ''
@@ -48,8 +49,8 @@ async function logout(browser, origin) {
 
 async function main() {
   const browser = await puppeteer.launch({
-    args: [`--remote-debugging-port=${PORT}`],
-    headless: false,
+    args: [`--remote-debugging-port=${PORT}`, `--no-sandbox`],
+    headless: HEADLESS,
     slowMo: 50,
   });
 

--- a/auth.js
+++ b/auth.js
@@ -2,12 +2,12 @@ const fs = require('fs');
 const puppeteer = require('puppeteer');
 const lighthouse = require('lighthouse');
 
-const HEADLESS = true
-const PORT = 8041; //debugging port
-const EMAIL = ''
-const PASSWORD = ''
-const LOGINURL = ''
-const TARGETURL = ''
+const HEADLESS = process.env.HEADLESS == "true" ? true : false
+const PORT = process.env.PORT || 8041; //debugging port
+const EMAIL = process.env.EMAIL || ''
+const PASSWORD = process.env.PASSWORD || ''
+const LOGINURL = process.env.LOGIN_URL || ''
+const TARGETURL = process.env.TARGET_URL || ''
 
 /**
  * @param {import('puppeteer').Browser} browser


### PR DESCRIPTION
Simple change to be able to run lighthouse via a docker container. Useful when wanting to run this as part of CI pipelines.